### PR TITLE
Various improvements to Teleirc Ansible role for Fedora bots

### DIFF
--- a/roles/teleirc/fedora/tasks/main.yml
+++ b/roles/teleirc/fedora/tasks/main.yml
@@ -7,11 +7,30 @@
     state: present
     name: git
 
+- name: create system user for Teleirc bots
+  user:
+    name: teleirc
+    comment: "System user to run RITlug/teleirc bots - do not use"
+    system: yes
+    home: "/usr/lib64/teleirc"
+    create_home: no
+
+- name: create group for Teleirc admins
+  group: name=teleirc
+
+- name: add target user to Teleirc admin group
+  user:
+    name: "{{ target_user }}"
+    groups: teleirc
+    append: yes
+
 - name: create root directory for Teleirc bots
   file:
     state: directory
     path: "/usr/lib64/teleirc"
     mode: 0755
+    owner: teleirc
+    group: teleirc
     seuser: system_u
 
 - name: git clone/pull RITlug/teleirc v1.2
@@ -41,12 +60,22 @@
 #
 # - name: install yarn
 # - name: yarn install
+- name: "set file permissions to teleirc:teleirc in /usr/lib64/teleirc/"
+  file:
+    state: directory
+    recurse: yes
+    path: "/usr/lib64/teleirc"
+    owner: teleirc
+    group: teleirc
+
 
 - name: add templated configuration
   template:
     src: env
     dest: "/usr/lib64/teleirc/{{ item.cn }}/.env"
     mode: 0640
+    owner: teleirc
+    group: teleirc
     seuser: system_u
   with_items:
     - "{{ bots.fedora }}"

--- a/roles/teleirc/fedora/tasks/main.yml
+++ b/roles/teleirc/fedora/tasks/main.yml
@@ -2,10 +2,26 @@
 - name: import Vault-encrypted variables with API tokens and Telegram chat IDs
   include_vars: vault.yml
 
-- name: install git
+- name: install/upgrade epel-release (CentOS only)
+  when: ansible_distribution == 'CentOS'
+  package:
+    state: latest
+    name: epel-release
+
+- name: add yarn third-party repository
+  get_url:
+    dest: "/etc/yum.repos.d/"
+    url: "https://dl.yarnpkg.com/rpm/yarn.repo"
+    setype: system_conf_t
+    seuser: system_u
+
+- name: install git, nodejs, yarn
   package:
     state: present
-    name: git
+    name:
+      - git
+      - nodejs
+      - yarn
 
 - name: create system user for Teleirc bots
   user:
@@ -56,10 +72,6 @@
     - "{{ bots.fedora_women }}"
     - "{{ bots.fedora_zh }}"
 
-# Too complex for now because of bad upstream packaging. Will revisit.
-#
-# - name: install yarn
-# - name: yarn install
 - name: "set file permissions to teleirc:teleirc in /usr/lib64/teleirc/"
   file:
     state: directory
@@ -68,6 +80,28 @@
     owner: teleirc
     group: teleirc
 
+- name: install dependencies via yarn
+  become_user: teleirc
+  command: "yarn install"
+  args:
+    chdir: "/usr/lib64/teleirc/{{ item.cn }}/"
+  with_items:
+    - "{{ bots.fedora }}"
+    - "{{ bots.fedora_ask }}"
+    - "{{ bots.fedora_commops }}"
+    - "{{ bots.fedora_diversity }}"
+    - "{{ bots.fedora_docs }}"
+    - "{{ bots.fedora_ec }}"
+    - "{{ bots.fedora_flock }}"
+    - "{{ bots.fedora_join }}"
+    - "{{ bots.fedora_latam }}"
+    - "{{ bots.fedora_mindshare }}"
+    - "{{ bots.fedora_marketing }}"
+    - "{{ bots.fedora_pa }}"
+    - "{{ bots.fedora_sq }}"
+    - "{{ bots.fedora_summer_coding }}"
+    - "{{ bots.fedora_women }}"
+    - "{{ bots.fedora_zh }}"
 
 - name: add templated configuration
   template:

--- a/roles/teleirc/fedora/tasks/main.yml
+++ b/roles/teleirc/fedora/tasks/main.yml
@@ -49,11 +49,12 @@
     group: teleirc
     seuser: system_u
 
-- name: git clone/pull RITlug/teleirc v1.2
+- name: git clone/pull RITlug/teleirc v1.2.1
   git:
     repo: "https://github.com/RITlug/teleirc.git"
     dest: "/usr/lib64/teleirc/{{ item.cn }}"
-    version: v1.2
+    version: v1.2.1
+    force: yes
   with_items:
     - "{{ bots.fedora }}"
     - "{{ bots.fedora_ask }}"

--- a/roles/teleirc/fedora/templates/teleirc.service
+++ b/roles/teleirc/fedora/templates/teleirc.service
@@ -5,6 +5,7 @@ After=multi-user.target
 
 [Service]
 Type=simple
+User=teleirc
 WorkingDirectory=/usr/lib64/teleirc/{{ item.cn }}
 ExecStart=/usr/bin/node teleirc.js
 Restart=always


### PR DESCRIPTION
This PR makes a few significant changes to how the Teleirc role works for the Fedora hosts. These changes are tested and currently used in production.

* Run all bots as non-privileged `teleirc` user
* Add tasks to install yarn and then install dependencies with yarn
* Upgrade to v1.2.1 to avoid package lock issue (could have been simplified with `force: yes` for git module, but oh well)

These changes will be iterated into #18 too.