### PR TITLE
Provision irc-lug.rit.edu for RIT FOSS, RITlug, and other misc. Teleirc bots

### DIFF
--- a/playbooks/bryn.yml
+++ b/playbooks/bryn.yml
@@ -7,5 +7,4 @@
     - base/centos/7
     - firewalld
     - sshd
-    - teleirc/default
     - yum-cron

--- a/playbooks/irc-lug.yml
+++ b/playbooks/irc-lug.yml
@@ -4,4 +4,8 @@
   become: yes
 
   roles:
+    - base/centos/7
+    - firewalld
+    - sshd
     - teleirc/default
+    - yum-cron

--- a/roles/teleirc/default/handlers/main.yml
+++ b/roles/teleirc/default/handlers/main.yml
@@ -11,6 +11,12 @@
   command: "yarn"
   args:
     chdir: "/usr/lib64/teleirc/{{ item.cn }}/"
+  with_items:
+    - "{{ bots.minecon_agents }}"
+    - "{{ bots.musicbrainz }}"
+    - "{{ bots.rit_foss }}"
+    - "{{ bots.ritlug }}"
+    - "{{ bots.ritlug_teleirc }}"
 
 - name: remove build dependencies
   package:

--- a/roles/teleirc/default/tasks/main.yml
+++ b/roles/teleirc/default/tasks/main.yml
@@ -52,7 +52,7 @@
     - "{{ bots.ritlug }}"
   notify:
     - install build dependencies
-    - install dependencies with yarn
+    - install runtime dependencies with yarn
     - remove build dependencies
 
 - name: git clone/pull RITlug/teleirc from HEAD (for testing bot)


### PR DESCRIPTION
This PR gets irc-lug.rit.edu provisioned and running. It puts the following Teleirc bridge bots into this node:

* MINECON Agents
* MusicBrainz
* RIT FOSS
* RITlug
* RITlug/teleirc

These changes are tested and currently deployed into production.

---

cc: @ritjoe @tjzabel @ct-martin — FYI ping: if there are any issues with the Teleirc bridge bots for the RIT channels in the future, this is the best place to look for now. I don't know if this belongs in a RITlug or RITFOSS repo, but until then…