### PR TITLE
Fix deprecation with inventory group name

### DIFF
--- a/inventory/inventory
+++ b/inventory/inventory
@@ -20,9 +20,9 @@ horizon
 happinesspackets.fedorainfracloud.org
 happinesspackets-stg.fedorainfracloud.org
 
-[fedora-happinesspackets]
+[fedora_happinesspackets]
 happinesspackets.fedorainfracloud.org
 happinesspackets-stg.fedorainfracloud.org
 
-[fedora-happinesspackets:vars]
+[fedora_happinesspackets:vars]
 ansible_user=root

--- a/playbooks/happiness-packets.yml
+++ b/playbooks/happiness-packets.yml
@@ -1,6 +1,6 @@
 ---
-- name: synchronize fedora-happinesspackets hosts
-  hosts: fedora-happinesspackets
+- name: synchronize fedora_happinesspackets hosts
+  hosts: fedora_happinesspackets
   become: yes
 
   roles:


### PR DESCRIPTION
This commit fixes a deprecation warning with the Ansible inventory group
names. Hyphens are no longer a supported character, so I converted all
hyphens to underscores.