### PR TITLE
inventory: Drop Fedora happiesspackets hosts

### DIFF
--- a/inventory/inventory
+++ b/inventory/inventory
@@ -1,28 +1,15 @@
 estrella.justinwflory.com
 horizon.justinwflory.com
-happinesspackets.fedorainfracloud.org
-happinesspackets-stg.fedorainfracloud.org
 
 [dev]
 127.0.0.1 ansible_connection=local
 
 [production]
 horizon
-happinesspackets.fedorainfracloud.org
 
 [staging]
 estrella
-happinesspackets-stg.fedorainfracloud.org
 
 [centos7]
 estrella
 horizon
-happinesspackets.fedorainfracloud.org
-happinesspackets-stg.fedorainfracloud.org
-
-[fedora_happinesspackets]
-happinesspackets.fedorainfracloud.org
-happinesspackets-stg.fedorainfracloud.org
-
-[fedora_happinesspackets:vars]
-ansible_user=root


### PR DESCRIPTION
This commit drops the Fedora Happiness Packets hosts provided by the
Fedora Infrastructure OpenStack cloud. This infrastructure is going away
at the end of the month and I no longer manage these servers.

So long… :wave: