### PR TITLE
inventory/playbooks: Move global group_vars to playbook

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -1,3 +1,0 @@
----
-target_user: jflory
-user_home_dir: /home/jflory

--- a/playbooks/hosts/horizon.yml
+++ b/playbooks/hosts/horizon.yml
@@ -3,6 +3,12 @@
   hosts: horizon.jwf.io
   become: yes
 
+  vars:
+    target_group: jflory
+    target_user: jflory
+    target_user_name: Justin W. Flory
+    user_home_dir: /home/jflory
+
   roles:
     - { role: base/centos-7, tags: base }
     - { role: firewalld, tags: firewalld }


### PR DESCRIPTION
This is a better practice. I already did this in `swiss-army`. Since the
values are usually host-specific, better to set them at the host-level.