### PR TITLE
roles: Miscellaneous clean-up

### DIFF
--- a/roles/nginx/files/html/index.html
+++ b/roles/nginx/files/html/index.html
@@ -2,7 +2,7 @@
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
     <head>
-        <title>Test Page for the Nginx HTTP Server on Fedora</title>
+        <title>Test Page for the Nginx HTTP Server</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <style type="text/css">
             /*<![CDATA[*/
@@ -102,13 +102,13 @@
 
             <div class="logos">
                 <a href="http://nginx.net/"><img
-                    src="nginx-logo.png" 
+                    src="nginx-logo.png"
                     alt="[ Powered by nginx ]"
                     width="121" height="32" /></a>
 
-                <a href="http://fedoraproject.org/"><img 
-                    src="poweredby.png" 
-                    alt="[ Powered by Fedora ]" 
+                <a href="http://fedoraproject.org/"><img
+                    src="poweredby.png"
+                    alt="[ Powered by Fedora ]"
                     width="88" height="31" /></a>
             </div>
         </div>

--- a/roles/teleirc/README.md
+++ b/roles/teleirc/README.md
@@ -1,8 +1,0 @@
-Teleirc role moved
-==================
-
-The Teleirc role was moved.
-It is in use across two other repositories:
-
-* [Fedora Teleirc SIG](https://pagure.io/sig-teleirc/infrastructure/blob/master/f/roles/teleirc)
-* [Rochester Institute of Technology, MAGIC Center](https://github.com/FOSSRIT/infrastructure/tree/master/roles/teleirc)

--- a/roles/yum-cron/tasks/main.yml
+++ b/roles/yum-cron/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
-- name: install yum-cron
+- name: install/upgrade yum-cron
   package:
     state: latest
     name: yum-cron
 
-- name: configure yum-cron (/etc/yum/yum-cron.conf)
+- name: push /etc/yum/yum-cron.conf
   template:
     src: yum-cron.conf
     dest: /etc/yum/yum-cron.conf


### PR DESCRIPTION
* nginx: Remove "on Fedora" from default index page
* teleirc: Get rid of it, it's been gone for a while now
* yum-cron: Use more clear language for some tasks