### PR TITLE
playbooks: Create wordpress group and set in manual playbook

### DIFF
--- a/inventory/inventory
+++ b/inventory/inventory
@@ -1,1 +1,4 @@
 horizon.jwf.io
+
+[wordpress]
+horizon.jwf.io

--- a/playbooks/manual/export-out-wordpress.yml
+++ b/playbooks/manual/export-out-wordpress.yml
@@ -1,6 +1,6 @@
 ---
-- name: bryn - export all data for single WordPress installation
-  hosts: bryn
+- name: export all data for a single WordPress installation
+  hosts: wordpress
   become: yes
 
   vars:
@@ -16,6 +16,7 @@
     mysql_user: wordpress
     site_dir: "/var/www/{{ site_fqdn }}"
     site_fqdn: blog.jwf.io
+    target_group: jflory
     target_user: jflory
     user_home_dir: "/home/jflory"
 
@@ -62,5 +63,5 @@
         format: zip
         remove: yes
         owner: "{{ target_user }}"
-        group: "{{ target_user }}"
+        group: "{{ target_group }}"
         seuser: system_u


### PR DESCRIPTION
This commit makes what was a one-off backup playbook into a more
reusable, manually-run playbook for creating WordPress blog backups.
Now, I only have to update the `wordpress` site in one place: the
`inventory` file. Instead of updating it in several playbooks.