### PR TITLE
mariadb[jubilee]: Add optimized config for less than 1GB of memory

### DIFF
--- a/roles/mariadb/handlers/main.yml
+++ b/roles/mariadb/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart mariadb.service
+  service:
+    name: mariadb.service
+    state: restarted

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -15,6 +15,17 @@
     - ansible_facts['os_family'] == "RedHat"
     - ansible_facts['distribution_major_version'] == "8"
 
+- name: push 999-custom.cnf to /etc/my.cnf.d/
+  template:
+    src: 999-custom.cnf
+    dest: /etc/my.cnf.d/999-custom.cnf
+    mode: 0644
+    owner: root
+    group: root
+    setype: mysqld_etc_t
+    seuser: system_u
+  notify: restart mariadb.service
+
 - name: start/enable mariadb.service
   service:
     name: mariadb.service

--- a/roles/mariadb/templates/999-custom.cnf
+++ b/roles/mariadb/templates/999-custom.cnf
@@ -1,0 +1,15 @@
+[mysqld]
+{% if ansible_hostname == "crystalcraftmc-web" %}
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#                                                                             #
+# crystalcraftmc-web: Optimize InnoDB to run on a server with less than 1GB   #
+# of memory. A buffer pool size under 1GB affects other InnoDB options.       #
+#                                                                             #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+# Commit ~90% of total system memory
+innodb_buffer_pool_size=725M
+
+# https://web.archive.org/web/20200318073756/https://www.percona.com/blog/2016/05/03/best-practices-for-configuring-optimal-mysql-memory-usage/
+innodb_flush_method=O_DIRECT
+{% endif %}


### PR DESCRIPTION
Add optimized configuration parameters for making this database fall
over a little bit less. Also trying my hand with templated,
host-specific logic. Might be able to replicate this for other things
too.